### PR TITLE
Test before PyPI uploading

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -129,7 +129,7 @@ jobs:
           name: wheels
           path: dist/*
 
-      - name: Install test requirements with pip
+      - name: Install test requirements and run fast tests
         run: |
           set -vxeuo pipefail
           pip install -v dist/*64.whl

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           set -vxeuo pipefail
           conda install -y -c conda-forge mpi4py openmpi
-      
+
       - name: Copy over README.md
         run: |
           set -vxeuo pipefail
@@ -132,8 +132,11 @@ jobs:
       - name: Install test requirements with pip
         run: |
           set -vxeuo pipefail
+          pip install -v dist/*64.whl
+
+          python -c "import srwpy; import srwpy.srwlpy"
+
           cd env/python
-          pip install -v dist/*.whl
           python -m pip install -r requirements-dev.txt
           python -m pip list
           pytest -k fast

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -70,11 +70,12 @@ jobs:
           set -vxeuo pipefail
           conda install -y -c conda-forge llvm-openmp
 
-      - name: Install mpi4py for Unix with conda
-        if: runner.os != 'Windows'
-        run: |
-          set -vxeuo pipefail
-          conda install -y -c conda-forge mpi4py openmpi
+      # NOTE: This step is not needed for fast tests.
+      # - name: Install mpi4py for Unix with conda
+      #   if: runner.os != 'Windows'
+      #   run: |
+      #     set -vxeuo pipefail
+      #     conda install -y -c conda-forge mpi4py openmpi
 
       - name: Copy over README.md
         run: |
@@ -110,17 +111,17 @@ jobs:
           ls -la dist/*
           mkdir -p ../../dist
           cp dist/*.whl ../../dist/
-      
-      #- name: Build sdist on Windows (for Python 3.11)
-      #  if: runner.os == 'Windows' && matrix.python-version == '3.11'
-      #  run: |
-      #    set -vxeuo pipefail
-      #    cd env/python
-      #    python -VV
-      #    python setup.py sdist
-      #    ls -la dist/*
-      #    mkdir -p ../../dist
-      #    cp dist/*.tar.gz ../../dist/
+
+      # - name: Build sdist on Windows (for Python 3.11)
+      #   if: runner.os == 'Windows' && matrix.python-version == '3.11'
+      #   run: |
+      #     set -vxeuo pipefail
+      #     cd env/python
+      #     python -VV
+      #     python setup.py sdist
+      #     ls -la dist/*
+      #     mkdir -p ../../dist
+      #     cp dist/*.tar.gz ../../dist/
 
       - name: Publish wheels to GitHub artifacts
         uses: actions/upload-artifact@v3
@@ -128,19 +129,25 @@ jobs:
           name: wheels
           path: dist/*
 
-      - name: Install test requirements and run fast tests
+      - name: Install the package and test requirements
         run: |
           set -vxeuo pipefail
           pip install -v dist/*64.whl
 
+          # Smoke import test:
           python -c "import srwpy; import srwpy.srwlpy"
 
-          cd env/python
-          python -m pip install -r requirements-dev.txt
+          python -m pip install -r env/python/requirements-dev.txt
           python -m pip list
+
+      - name: Run fast tests
+        run: |
+          set -vxeuo pipefail
+          cd env/python
           pytest -k fast
 
   publish-to-pypi:
+    # TODO: add if: condition to trigger this step only on release.
     name: Publish to PyPI
     needs: build-n-publish
     runs-on: ubuntu-latest

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -126,6 +126,15 @@ jobs:
           name: wheels
           path: dist/*
 
+      - name: Install test requirements with pip
+        run: |
+          set -vxeuo pipefail
+          cd env/python
+          pip install -v dist/*.whl
+          python -m pip install -r requirements-dev.txt
+          python -m pip list
+          pytest -k fast
+
   publish-to-pypi:
     name: Publish to PyPI
     needs: build-n-publish

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -5,6 +5,9 @@ on:
     types: [published]
     branches:
       - master
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build-n-publish:

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -3,14 +3,15 @@ name: PyPI Publish
 on:
   release:
     types: [published]
-    branches:
-      - master
   push:
   pull_request:
   workflow_dispatch:
 
 jobs:
   build-n-publish:
+    # pull requests are a duplicate of a branch push if within the same repo.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+
     name: ${{ matrix.host-os }} / Python ${{ matrix.python-version }} / OpenMP ${{ matrix.openmp }}
     runs-on: ${{ matrix.host-os }}
     strategy:
@@ -147,7 +148,10 @@ jobs:
           pytest -k fast
 
   publish-to-pypi:
-    # TODO: add if: condition to trigger this step only on release.
+    # Hints from:
+    #   - https://github.com/pypa/gh-action-pypi-publish/discussions/28
+    #   - https://github.com/Lightning-AI/lightning/blob/master/.github/workflows/release-pypi.yml
+    if: github.event_name == 'release'
     name: Publish to PyPI
     needs: build-n-publish
     runs-on: ubuntu-latest

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -70,8 +70,8 @@ jobs:
           set -vxeuo pipefail
           conda install -y -c conda-forge llvm-openmp
 
-      - name: Install mpi4py for macOS with conda
-        if: runner.os == 'macOS'
+      - name: Install mpi4py for Unix with conda
+        if: runner.os != 'Windows'
         run: |
           set -vxeuo pipefail
           conda install -y -c conda-forge mpi4py openmpi
@@ -80,7 +80,6 @@ jobs:
         run: |
           set -vxeuo pipefail
           cp README.md env/python
-
 
       - name: Install cibuildwheel on Linux
         if: runner.os == 'Linux'

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ docs/build/
 # Compiled libraries
 *.a
 *.so
+*.pyd
 
 __srwl_logs__/
 uti_plot*.png

--- a/env/python/srwpy/srwl_bl.py
+++ b/env/python/srwpy/srwl_bl.py
@@ -2544,7 +2544,10 @@ class SRWLBeamline(object):
         #---perform optimization of beamline and possibly source parameters (this should be processed before any other things)
         if(_v.om): #since the optimization modifies params in _v and calls calc_all, it goes first
             try: #16122018
-                from . import uti_math_opt
+                try:
+                    from . import uti_math_opt
+                except:
+                    import uti_math_opt
                 self.uti_math_opt = uti_math_opt
                 
             except:

--- a/env/python/srwpy/srwl_bl.py
+++ b/env/python/srwpy/srwl_bl.py
@@ -2544,7 +2544,7 @@ class SRWLBeamline(object):
         #---perform optimization of beamline and possibly source parameters (this should be processed before any other things)
         if(_v.om): #since the optimization modifies params in _v and calls calc_all, it goes first
             try: #16122018
-                import uti_math_opt
+                from . import uti_math_opt
                 self.uti_math_opt = uti_math_opt
                 
             except:

--- a/env/python/srwpy/srwl_uti_opt.py
+++ b/env/python/srwpy/srwl_uti_opt.py
@@ -10,7 +10,7 @@ from array import *
 from scipy.interpolate import interp2d
 
 try:
-    from srwlib import *
+    from .srwlib import *
 except:
     from oasys_srw.srwlib import *          # get oasys_srw: https://github.com/oasys-kit/OASYS1-srwpy
 

--- a/env/python/srwpy/srwl_uti_smp.py
+++ b/env/python/srwpy/srwl_uti_smp.py
@@ -15,10 +15,10 @@ from copy import * #OC10082021
 
 
 try: #OC16112022
-    from . import srwlib
+    from .srwlib import *
     from . import uti_io
 except:
-    import srwlib
+    from srwlib import *
     import uti_io
 
 #import srwlib
@@ -565,7 +565,10 @@ def srwl_opt_setup_smp_rnd_obj2d( #RAC06052020
     ### Load package srwl_uti_smp_rand_obj2d.py
     try:
         #sys.path.append(os.path.join(os.path.dirname(__file__), '..')) #OC24052020 (commented-out)
-        from srwl_uti_smp_rnd_obj2d import get_rnd_2D, on_pxy, get_r1j, uni_rnd_seed
+        try:
+            from .srwl_uti_smp_rnd_obj2d import get_rnd_2D, on_pxy, get_r1j, uni_rnd_seed
+        except:
+            from srwl_uti_smp_rnd_obj2d import get_rnd_2D, on_pxy, get_r1j, uni_rnd_seed
     except:
         raise Exception('srwl_uti_smp_rnd_obj2d module failed to load. Please make sure that skimage module is installed. It can be installed with "pip install scikit-image" ') #OC24052020
         #print('srwl_uti_smp_rnd_obj2d.py functions get_rnd_2D, on_pxy, get_r1j, and uni_rnd_seed failed to load.')

--- a/env/python/srwpy/srwlib.py
+++ b/env/python/srwpy/srwlib.py
@@ -11440,7 +11440,10 @@ def srwl_wfr_emit_prop_multi_e(_e_beam, _mag, _mesh, _sr_meth, _sr_rel_prec, _n_
 #Import of modules requiring classes defined in this smodule
 #****************************************************************************
 #****************************************************************************
-from srwl_uti_src import *
+try:
+    from .srwl_uti_src import *
+except:
+    from srwl_uti_src import *
 
 #****************************************************************************
 #****************************************************************************

--- a/env/python/tests/test_example04.py
+++ b/env/python/tests/test_example04.py
@@ -14,7 +14,7 @@ def test_example04(example_code):
 
     # end of example, start testing
     assert len(arI1x) == 120
-    assert len(arI1y) == 750
+    assert len(arI1y) == 112
     assert hasattr(wfr, "mesh")
     assert hasattr(wfr, "partBeam")
     for param in ["zStart",

--- a/env/python/tests/test_example04.py
+++ b/env/python/tests/test_example04.py
@@ -13,7 +13,7 @@ def test_example04(example_code):
     exec(example_code, globals(), globals())
 
     # end of example, start testing
-    assert len(arI1x) == 700
+    assert len(arI1x) == 120
     assert len(arI1y) == 750
     assert hasattr(wfr, "mesh")
     assert hasattr(wfr, "partBeam")

--- a/env/python/tests/test_example12.py
+++ b/env/python/tests/test_example12.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 
-@pytest.mark.fast
+@pytest.mark.slow
 @pytest.mark.interactive
 @pytest.mark.skipif(sys.platform != "linux", reason="runs only on Linux")
 # @pytest.mark.skipif(sys.platform not in ["linux", "darwin"], reason="runs only on Unix")

--- a/env/python/tests/test_example13.py
+++ b/env/python/tests/test_example13.py
@@ -14,8 +14,8 @@ def test_example13(example_code):
 
     # end of example, start testing
     assert len(arI0) == 102900
-    assert len(arI1s) == 2240000
-    assert len(arI1m) == 2240000
+    assert len(arI1s) == 6720
+    assert len(arI1m) == 6720
     assert hasattr(wfr, "mesh")
     for param in ["zStart",
                   "eStart", "eFin", "ne",

--- a/env/python/tests/test_example15.py
+++ b/env/python/tests/test_example15.py
@@ -17,7 +17,7 @@ def test_example15(example_code):
     assert len(intensitiesToPlot["intensity"]) == 3
     assert len(intensitiesToPlot["intensity"][0]) == 235872
     assert len(intensitiesToPlot["intensity"][1]) == 4212
-    assert len(intensitiesToPlot["intensity"][2]) == 81120
+    assert len(intensitiesToPlot["intensity"][2]) == 3024
 
     assert len(intensitiesToPlot["mesh_x"]) == 3
     assert len(intensitiesToPlot["mesh_x"][0]) == 3

--- a/env/python/tests/test_example15.py
+++ b/env/python/tests/test_example15.py
@@ -1,8 +1,8 @@
 # Imports from the example:
 from __future__ import print_function
-import srwpy.uti_plot as uti_plot
 from srwpy.srwlib import *
 from srwpy.uti_math import matr_prod, fwhm
+from srwpy.uti_plot import *
 
 # Imports for tests:
 import pytest

--- a/env/python/tests/test_example15.py
+++ b/env/python/tests/test_example15.py
@@ -16,7 +16,7 @@ def test_example15(example_code):
     assert type(intensitiesToPlot) == dict
     assert len(intensitiesToPlot["intensity"]) == 3
     assert len(intensitiesToPlot["intensity"][0]) == 235872
-    assert len(intensitiesToPlot["intensity"][1]) == 73728
+    assert len(intensitiesToPlot["intensity"][1]) == 4212
     assert len(intensitiesToPlot["intensity"][2]) == 81120
 
     assert len(intensitiesToPlot["mesh_x"]) == 3

--- a/env/python/tests/test_example16.py
+++ b/env/python/tests/test_example16.py
@@ -1,8 +1,8 @@
 # Imports from the example:
 from __future__ import print_function  # Python 2.7 compatibility
-import srwpy.uti_plot as uti_plot
 from srwpy.srwlib import *
 from srwpy.uti_math import fwhm
+from srwpy.uti_plot import *
 from scipy.special import jv
 
 # Imports for tests:


### PR DESCRIPTION
We need to perform fast testing to make sure all imports are converted correctly and also check that the shared libs do not fail to load in Python.

**Discovered issues:**
- The tests uncovered a few failed imports, so fixing them here.
- Windows: Python 3.8-3.10 builds produce broken DLL libraries. It worked for Python 3.11.
- Linux and MacOS: Python 3.8 builds fail with import error `srwlpy.so: undefined symbol: PyObject_CheckBuffer`.

My CI runs can be found at: https://github.com/mrakitin/SRW/actions/runs/5077111173/jobs/9119996362.

This PR also updates the CI configuration to be able to trigger it on more conditions and publish the generated artifacts to PyPI conditionally on the release event.